### PR TITLE
Fix IndexError reading ImageJ hyperstacks stored as single physical TIFF page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning][].
 
 ### Fixes
 
+## [0.3.7]
+
+### Fixes
+
+- Fix `IndexError` when reading ImageJ hyperstacks stored as a single physical TIFF page (e.g. contiguous multi-frame files from some microscope acquisitions). Falls back to `tif.asarray()` when `tif.pages` has fewer entries than the requested frame index.
+
 ## [0.1.1]
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "fishtank"
-version = "0.3.6"
+version = "0.3.7"
 description = "A collection of tools for processing MERFISH data"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/fishtank/io/read.py
+++ b/src/fishtank/io/read.py
@@ -488,7 +488,12 @@ def read_img(
             with tiff.TiffFile(path) as tif:
                 pages = tif.pages
                 if isinstance(frame_indices, list | tuple | np.ndarray):
-                    img = np.stack([pages[i].asarray() for i in frame_indices])
+                    if len(pages) <= max(frame_indices):
+                        # ImageJ hyperstacks stored as a single physical page require
+                        # asarray() to access virtual frames; pages[i] only sees page 0.
+                        img = tif.asarray()[np.array(frame_indices)]
+                    else:
+                        img = np.stack([pages[i].asarray() for i in frame_indices])
                 else:
                     img = pages[frame_indices].asarray()
             img = np.squeeze(img)


### PR DESCRIPTION
## Summary

- Some microscope acquisitions write multi-frame TIFFs where all frames are packed into a single contiguous physical page in ImageJ hyperstack format
- `tifffile` exposes only 1 entry in `tif.pages` for these files, so `pages[i]` raises `IndexError: index out of range` for any frame beyond index 0 (e.g. z-slice 30, color 405 → frame index 123)
- Fix falls back to `tif.asarray()[frame_indices]` when `len(pages)` is smaller than the requested frame index, which correctly decodes all virtual frames from the single physical page

## Test plan

- [ ] Run `fishtank mosaic` on a TIFF file with ImageJ hyperstack stored as a single physical page and verify no `IndexError`
- [ ] Confirm existing multi-page TIFF reads are unaffected (code only takes the new path when `len(pages) <= max(frame_indices)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)