### PR TITLE
Fix detect-spots: remove hot pixels so drift is not pinned to [0,0]

### DIFF
--- a/src/fishtank/scripts/detect_spots_script.py
+++ b/src/fishtank/scripts/detect_spots_script.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import skimage as ski
+from scipy.ndimage import median_filter
 
 import fishtank as ft
 
@@ -29,6 +30,63 @@ def _get_filter(name, filter_args):
     else:
         raise ValueError(f"Filter {name} not found in fishtank.filters or skimage.filters")
 
+def _remove_hot_pixels(img, size=3, ratio=5.0, sigma_floor=5.0):
+    """Replace isolated hot/dead pixels with their local median before registration.
+
+    Hot/defective camera pixels sit at FIXED detector positions, so they are identical
+    in every series and dominate phase_cross_correlation -- pinning the estimated drift
+    to [0, 0] when the (bead/fiducial) registration channel is dim. They are isolated
+    single-pixel spikes whose value is far above the *local* median; a real fiducial
+    bead spans several pixels (the PSF) and so sits on a bright neighborhood with a value
+    close to its local median. That difference is what lets us drop hot pixels while
+    leaving beads untouched.
+
+    Why not just clip at a fixed maximum (e.g. value == dtype max)? A fixed cutoff is
+    detector-specific and only catches FULLY SATURATED pixels; a hot pixel reading e.g.
+    12000 on a ~100 background is just as disruptive but slips through. The local-median
+    ratio test below is intensity-agnostic and catches saturated and sub-saturation hot
+    pixels alike, without flagging a real (bright but spatially extended) bead.
+
+    Parameters
+    ----------
+    img
+        2D registration image (a single bead/fiducial frame).
+    size
+        Side length (pixels) of the square window for the local median. 3 isolates
+        single-pixel spikes; larger windows also catch small clusters but risk eroding
+        faint beads.
+    ratio
+        A pixel is flagged when its value exceeds ``ratio`` x its local median. Hot
+        pixels sit on background, so this ratio is large (~10-600 observed); real bead
+        cores sit on a bright neighborhood, so theirs is ~1-2. ratio=5 separates them.
+    sigma_floor
+        Also require the excess over the local median to exceed ``sigma_floor`` times the
+        background-noise standard deviation. This stops faint noise blips on near-zero
+        background (where the ratio alone can be large) from being flagged. Units: sigma.
+
+    Returns
+    -------
+    Copy of ``img`` with hot pixels replaced by their local median (unchanged if none).
+    """
+    local_median = median_filter(img, size=size, mode="nearest").astype(np.float64)
+    excess = img.astype(np.float64) - local_median  # height of each pixel above its neighbours
+
+    # Robust background-noise scale from the spread of `excess`. MAD = median absolute
+    # deviation; unlike the plain std it is not inflated by the few hot pixels / bead
+    # edges we are hunting. For Gaussian noise sigma = 1.4826 * MAD, where
+    # 1.4826 = 1 / norm.ppf(0.75) is the fixed factor converting MAD to a standard
+    # deviation -- giving a hot-pixel-resistant estimate of the noise sigma.
+    mad = float(np.median(np.abs(excess - np.median(excess))))
+    noise_sigma = 1.4826 * mad
+
+    # Hot pixel = isolated spike (value >> local median) that also clears the noise floor.
+    hot = (img > ratio * np.maximum(local_median, 1.0)) & (excess > sigma_floor * noise_sigma)
+    if hot.any():
+        img = img.copy()
+        img[hot] = local_median[hot].astype(img.dtype)
+    return img
+
+
 def _get_reg_img(img, reg_bit, reg_color, channels, reg_z_slice=None, z_drift=False, clip_pct=None):
     """Return the registration image and initialize the drift vector."""
     if reg_color is not None:
@@ -45,6 +103,7 @@ def _get_reg_img(img, reg_bit, reg_color, channels, reg_z_slice=None, z_drift=Fa
         reg_img = reg_img.max(axis=0)
     else:
         reg_img = reg_img.max(axis=(0, 1))
+    reg_img = _remove_hot_pixels(reg_img)
     if clip_pct is not None:
         reg_img = np.minimum(reg_img / np.percentile(reg_img, clip_pct, axis=(-2, -1), keepdims=True), 1)
     return reg_img
@@ -61,6 +120,7 @@ def _load_reg_img(input, fov, series, reg_bit, reg_color, channels, file_pattern
                              z_slices=reg_z_slice,file_pattern=file_pattern)[0]
     if reg_z_slice is None and not z_drift:
         reg_img = reg_img.max(axis=0)
+    reg_img = _remove_hot_pixels(reg_img)
     if clip_pct is not None:
         reg_img = np.minimum(reg_img / np.percentile(reg_img, clip_pct, axis=(-2, -1), keepdims=True), 1)
     return reg_img


### PR DESCRIPTION
## Summary

In `detect-spots`, the per-series drift is estimated with
`ski.registration.phase_cross_correlation(reg_img, series_reg_img)` on the raw
registration (bead/fiducial) images. When the registration channel is dim, a
**single saturated pixel** (value = dtype max, e.g. `65535` for `uint16`) sitting
at a **fixed camera position** — identical in the reference and in every moving
image — dominates the cross-correlation and pins the estimated drift to exactly
`[0, 0]` for **every** series. No exception and no warning is raised, so the run
completes "successfully" with zero alignment, and downstream decoding yields
nothing.

## Environment

- fishtank 0.3.6 (also present in current `main`; the drift code is unchanged)
- MERFISH-X 60x acquisition; registration bit = `beads` (color 488), `--reg_z_slice 0`
- Registration images are `uint16`, 2048×2048, read via a per-series frame table

## Steps to reproduce / evidence

Reference and one moving round, registration (488 @ z0) frame each:

```
ref  bead frame: mean=243.8 std=624.3 sat(==65535)=1
test bead frame: mean=115.5 std=37.1  sat(==65535)=1     # dim bead channel
saturated pixels at the SAME (y,x) in BOTH images: 1      # fixed hot pixel
```

Drift under preprocessing applied identically to both images:

```
raw                          : [0.0, 0.0]    # phase_cross_correlation as fishtank calls it
clip to 99.9th percentile    : [7.2, -1.5]   # real drift recovered
de-saturate (drop ==65535)   : [7.2, -1.5]   # real drift recovered
high-pass (gaussian sigma=10): [0.0, 0.0]    # NOT fixed (sharpens the hot pixel)
```

A single `65535` pixel is enough: it is the brightest feature by ~100x in the dim
moving image, it is at the same location in both images (camera defect), so the
correlation peak lands at zero shift. Two *unrelated* images (e.g. the reference
bead frame vs. an RNA frame from the moving file) also return exactly `[0, 0]` for
the same reason — a tell-tale sign that a shared fixed pixel, not the beads, is
driving the result.

## Why it isn't caught

The only guard on a degenerate drift is
`if np.max(series_reg_img) < reg_min_intensity:` (default 1000). The saturated
pixel makes `np.max == 65535`, so the guard passes and the bogus `[0, 0]` is
accepted. There is no check that the registration image actually contains
trackable structure rather than one hot pixel.

## Proposed fix

Remove **isolated hot/dead pixels** from the registration image before correlation.
The key signal is spatial, not absolute intensity: a hot pixel's value far exceeds
its *local median* (it is an isolated spike on background), whereas a real fiducial
bead sits on a bright neighborhood (value ≈ local median, since the PSF spans several
pixels). This is detector-agnostic — it catches saturated *and* sub-max hot pixels
without hardcoding a saturation value — surgical (real beads are untouched), and does
not rescale intensities (so it does not interact with `--reg_min_intensity`, unlike
`--reg_clip_pct`). Applied in both `_get_reg_img` and `_load_reg_img` in
`src/fishtank/scripts/detect_spots_script.py`:

```python
from scipy.ndimage import median_filter

def _remove_hot_pixels(img, size=3, ratio=5.0, sigma_floor=5.0):
    """Replace isolated hot/dead pixels with their local median before registration.

    A hot pixel is an isolated spike: its value is far above its *local* median. A real
    fiducial bead spans several pixels (the PSF), so it sits on a bright neighborhood
    with value ~ local median. We use that to drop hot pixels and keep beads.

    Parameters
    ----------
    img         : 2D registration image (a single bead frame).
    size        : square-window side (px) for the local median; 3 targets single-pixel spikes.
    ratio       : flag if value > ratio * local median (hot ~10-600; bead cores ~1-2).
    sigma_floor : also require excess over the local median > sigma_floor * background-noise
                  sigma, so faint noise blips on near-zero background are not flagged.
    """
    local_median = median_filter(img, size=size, mode="nearest").astype(np.float64)
    excess = img.astype(np.float64) - local_median
    # Robust noise scale: MAD = median absolute deviation (not inflated by the spikes we
    # seek). For Gaussian noise sigma = 1.4826 * MAD (1.4826 = 1/norm.ppf(0.75) converts
    # MAD to a standard deviation).
    mad = float(np.median(np.abs(excess - np.median(excess))))
    noise_sigma = 1.4826 * mad
    hot = (img > ratio * np.maximum(local_median, 1.0)) & (excess > sigma_floor * noise_sigma)
    if hot.any():
        img = img.copy()
        img[hot] = local_median[hot].astype(img.dtype)
    return img
```

inserting `reg_img = _remove_hot_pixels(reg_img)` just before the existing
`if clip_pct is not None:` block in each function. (Full diff in
`fix_reg_hot_pixels.patch`.)

**Validation on real data** (one FOV, 26 rounds): the detector flags ~10 isolated
hot pixels per frame (1 saturated at 65535, ~9 sub-max at fixed positions, values
~500–2500) and **zero** real bead pixels (beads have value/local-median ≈ 1.2–1.4 vs
10–600 for hot pixels). Recovered drift is identical (<0.1 px) whether we remove only
the saturated pixel or all isolated hot pixels — confirming it fixes the bug and does
not disturb the (real, monotonic) stage drift. The sub-max hot pixels did not cause
*this* dataset's failure (only the saturated one dominated), but a dominant sub-max
hot pixel on dimmer data would — which a saturation-only rule would miss.

Optionally, also emit a warning when `phase_cross_correlation` returns exactly
`[0, 0]` for a non-reference series, since that is almost always spurious.

## Workaround without code changes

`--reg_clip_pct 99.9` also recovers the correct drift, **but** it normalizes the
registration image to a max of 1.0, which then trips the
`np.max(series_reg_img) < reg_min_intensity` guard — so it must be combined with a
low `--reg_min_intensity` (e.g. `0`). The `_remove_hot_pixels` fix avoids this footgun.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
