### PR TITLE
Fix read_img: avoid skimage plugin FutureWarning

### DIFF
--- a/src/fishtank/io/read.py
+++ b/src/fishtank/io/read.py
@@ -270,6 +270,18 @@ def _read_frame_table(path: str | pathlib.Path) -> tuple[np.ndarray, list[float]
     return color_order, z_offsets, cz_to_frame, n_rows
 
 
+def _imread(path, plugin=None, **plugin_args):
+    """Call ``skimage.io.imread`` without the deprecated ``plugin`` argument when unset.
+
+    skimage >= 0.25 emits a FutureWarning whenever the ``plugin`` parameter is passed,
+    even as ``None``. fishtank reads pass ``plugin=None`` by default, so only forward it
+    when a plugin is actually requested.
+    """
+    if plugin is not None:
+        return ski.io.imread(path, plugin=plugin, **plugin_args)
+    return ski.io.imread(path, **plugin_args)
+
+
 def read_img(
     path: str | pathlib.Path,
     colors: int | str | list = None,
@@ -468,7 +480,7 @@ def read_img(
         if suffix == ".dax":
             img = read_dax(path, shape=shape, frames=frame_indices, **plugin_args)
         else:
-            raw = ski.io.imread(path, plugin=plugin, **plugin_args)
+            raw = _imread(path, plugin=plugin, **plugin_args)
             img = raw[frame_indices]
     else:
         # Get frame indices for non-sparse (rectangular) case
@@ -498,7 +510,7 @@ def read_img(
                     img = pages[frame_indices].asarray()
             img = np.squeeze(img)
         else:
-            img = ski.io.imread(path, plugin=plugin, **plugin_args)[frame_indices]
+            img = _imread(path, plugin=plugin, **plugin_args)[frame_indices]
             img = np.squeeze(img)
     # Reshape image if necessary
     if n_colors > 1:


### PR DESCRIPTION
# fishtank GitHub issue — read_img: skimage `plugin` FutureWarning

Repo: https://github.com/jweissmanlab/fishtank

---

## Title

`read_img` triggers a skimage `FutureWarning` (deprecated `plugin` parameter) on
every non-dax read

## Summary

`read_img` calls `ski.io.imread(path, plugin=plugin, **plugin_args)` with the
default `plugin=None`. As of scikit-image 0.25 the `plugin` parameter is deprecated,
and passing it — **even as `None`** — emits a `FutureWarning` on every call. In an
array job that reads many series per FOV this floods the logs:

```
.../fishtank/io/read.py:471: FutureWarning: The plugin infrastructure in
`skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will
be removed in 0.27 (or later). To avoid this warning, please do not use the
parameter `plugin`. ...
  raw = ski.io.imread(path, plugin=plugin, **plugin_args)
```

Two call sites are affected in `read_img` (`src/fishtank/io/read.py`): the
sparse/frame-table branch (`raw = ski.io.imread(...)`) and the final rectangular
branch (`img = ski.io.imread(...)[frame_indices]`).

## Proposed fix

Forward `plugin` only when it is actually set. A tiny helper keeps both call sites
clean and preserves behavior when a plugin *is* requested:

```python
def _imread(path, plugin=None, **plugin_args):
    """skimage.io.imread without the deprecated `plugin` arg when unset."""
    if plugin is not None:
        return ski.io.imread(path, plugin=plugin, **plugin_args)
    return ski.io.imread(path, **plugin_args)
```

Then replace the two `ski.io.imread(path, plugin=plugin, **plugin_args)` calls with
`_imread(path, plugin=plugin, **plugin_args)`. Full diff in
`fix_imread_deprecation.patch`. No behavior change; the warning disappears when
`plugin` is None (the default), and an explicit `plugin=...` still works.
