### PR TITLE
Warn when --scale_factor disagrees with XML objective resolution

### DIFF
--- a/src/fishtank/scripts/detect_spots_script.py
+++ b/src/fishtank/scripts/detect_spots_script.py
@@ -285,6 +285,14 @@ def detect_spots(
     logger.info(f"Loading reference series {ref_series}")
     ref_channels = channels.query("series == @ref_series & bit not in @reg_bit and bit not in @exclude_bits")
     ref_img, ref_attr = ft.io.read_fov(input, fov, channels=ref_channels, file_pattern=file_pattern, z_slices=z_slices)
+    # Warn if the requested scale_factor disagrees with the objective resolution in the XML metadata.
+    xml_resolution = ref_attr.get("micron_per_pixel")
+    if scale_factor is not None and xml_resolution is not None and not np.isclose(scale_factor, xml_resolution, atol=1e-4):
+        logger.warning(
+            f"Specified --scale_factor ({scale_factor}) does not match the objective resolution in the "
+            f"XML metadata ({xml_resolution} micron/pixel). Using the specified value; "
+            f"check that this is intended."
+        )
     reg_img = _load_reg_img(input, fov, ref_series, reg_bit, reg_color, channels, file_pattern, reg_z_slice, z_drift, reg_clip_pct)
     current_drift = np.zeros(3, dtype=int) if z_drift else np.zeros(2, dtype=int)
     # Get common image

--- a/tests/test_detect_spots.py
+++ b/tests/test_detect_spots.py
@@ -37,5 +37,36 @@ def test_detect_spots_3d(caplog):
     assert "Saving results in tests/output/spots" in caplog.text
 
 
+def test_detect_spots_scale_factor_mismatch_warns(caplog):
+    parser = ft.scripts.detect_spots_script.get_parser()
+    args = parser.parse_args(
+        [
+            "-i",
+            "./tests/data/merfish",
+            "-o",
+            "./tests/output/spots",
+            "--fov",
+            "0",
+            "--ref_series",
+            "H0R1",
+            "--common_bits",
+            "r52,r53",
+            "--filter",
+            "unsharp_mask",
+            "--filter_args",
+            "sigma=10",
+            "--z_drift",
+            "True",
+            "--scale_factor",
+            "0.09",  # XML objective resolution is 0.107
+        ]
+    )
+    with caplog.at_level(logging.WARNING):
+        kwargs = vars(args)
+        kwargs.pop("func")
+        ft.scripts.detect_spots(**kwargs)
+    assert "does not match the objective resolution" in caplog.text
+
+
 if __name__ == "__main__":
     pytest.main(["-v", __file__])


### PR DESCRIPTION
## Summary

`detect-spots` now warns in the log when the requested `--scale_factor`
disagrees with the objective resolution (`micron_per_pixel`) parsed from the
XML metadata.

The pixel→micron `scale_factor` only affects the `global_x`/`global_y`
coordinates written to `spots_{fov}.csv`. An incorrect value produces silently
wrong global coordinates that are easy to miss until much later in the pipeline.
This adds an early guardrail: the warning fires right after the reference FOV is
loaded, before spot detection, so it lands near the top of the per-FOV log.

## Behavior

- Fires only when `--scale_factor` is explicitly set and differs from the XML
  objective resolution (compared with `np.isclose(..., atol=1e-4)`).
- Non-fatal: the specified value is still used, so this changes no output — it
  only surfaces the discrepancy for the user to confirm.
- No warning when `--scale_factor` is omitted (the XML value is used by default)
  or when it matches the XML.

Example message:

```
[FOV 42] Specified --scale_factor (0.09) does not match the objective resolution
in the XML metadata (0.107 micron/pixel). Using the specified value; check that
this is intended.
```

## Tests

Adds `test_detect_spots_scale_factor_mismatch_warns`, which runs `detect-spots`
with a `--scale_factor` that disagrees with the test XML (0.107) and asserts the
warning is logged. Full suite passes (34 passed, 9 slow-skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
